### PR TITLE
Add CYDSynth example with touch-controlled frequency synthesis

### DIFF
--- a/examples/CYDSynth/CYDSynth.ino
+++ b/examples/CYDSynth/CYDSynth.ino
@@ -8,6 +8,7 @@
 #define I2S_PORT I2S_NUM_0
 #define WAVE_WIDTH 320
 #define WAVE_HEIGHT 240
+#define I2S_COMM_FORMAT_STAND_I2S (I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB)
 
 TFT_eSPI tft = TFT_eSPI();
 float phase = 0.0f;
@@ -19,14 +20,17 @@ void setup() {
   tft.init();
   tft.setRotation(3);
   tft.fillScreen(TFT_BLACK);
-  tft.initTouch();
+
+  if (!tft.initTouch()) {
+    Serial.println("Touch initialization failed");
+  }
 
   i2s_config_t i2s_config = {
     .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
     .sample_rate = SAMPLE_RATE,
     .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
     .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-    .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+    .communication_format = (i2s_comm_format_t)I2S_COMM_FORMAT_STAND_I2S,
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
     .dma_buf_count = 8,
     .dma_buf_len = BUFFER_SIZE,
@@ -42,8 +46,17 @@ void setup() {
     .data_in_num = I2S_PIN_NO_CHANGE
   };
 
-  i2s_driver_install(I2S_PORT, &i2s_config, 0, NULL);
-  i2s_set_pin(I2S_PORT, &pin_config);
+  esp_err_t result = i2s_driver_install(I2S_PORT, &i2s_config, 0, NULL);
+  if (result != ESP_OK) {
+    Serial.println("Error installing I2S driver");
+    while(1);
+  }
+
+  result = i2s_set_pin(I2S_PORT, &pin_config);
+  if (result != ESP_OK) {
+    Serial.println("Error setting I2S pins");
+    while(1);
+  }
 }
 
 void loop() {

--- a/examples/CYDSynth/User_Setup.h
+++ b/examples/CYDSynth/User_Setup.h
@@ -1,0 +1,31 @@
+#define USER_SETUP_INFO "Setup for CYD ESP32 2.8\" display"
+
+#define ILI9341_DRIVER
+
+#define TFT_MISO 12
+#define TFT_MOSI 13
+#define TFT_SCLK 14
+#define TFT_CS   15
+#define TFT_DC    2
+#define TFT_RST   4
+
+#define TOUCH_CS 21
+
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+
+#define SMOOTH_FONT
+
+#define TFT_WIDTH  240
+#define TFT_HEIGHT 320
+
+#define SPI_FREQUENCY  40000000
+#define SPI_READ_FREQUENCY  20000000
+#define SPI_TOUCH_FREQUENCY  2500000
+
+#define TOUCH_DRIVER 0x2046


### PR DESCRIPTION
This PR adds a new example sketch `CYDSynth` that demonstrates audio synthesis and visualization on the CYD ESP32 board. Key features include:

- Real-time sine wave synthesis using I2S audio output
- Touchscreen frequency control (100-2000 Hz)
- Waveform visualization on TFT display
- Error handling for I2S and touch initialization
- Custom TFT_eSPI configuration for CYD ESP32 2.8" display

The example includes:
1. Main sketch file with audio synthesis and display logic
2. Display configuration file with pin definitions for the CYD board

Note: The User_Setup.h file needs to be copied to the TFT_eSPI library folder for proper display configuration.