### PR TITLE
Update CYDSynth example with improved display and touch handling

### DIFF
--- a/examples/CYDSynth/User_Setup.h
+++ b/examples/CYDSynth/User_Setup.h
@@ -1,16 +1,12 @@
-#define USER_SETUP_INFO "Setup for CYD ESP32 2.8\" display"
-
+#define USER_SETUP_INFO "User_Setup"
 #define ILI9341_DRIVER
-
 #define TFT_MISO 12
 #define TFT_MOSI 13
 #define TFT_SCLK 14
 #define TFT_CS   15
 #define TFT_DC    2
 #define TFT_RST   4
-
-#define TOUCH_CS 21
-
+#define TOUCH_CS 33
 #define LOAD_GLCD
 #define LOAD_FONT2
 #define LOAD_FONT4
@@ -18,14 +14,6 @@
 #define LOAD_FONT7
 #define LOAD_FONT8
 #define LOAD_GFXFF
-
 #define SMOOTH_FONT
-
-#define TFT_WIDTH  240
-#define TFT_HEIGHT 320
-
 #define SPI_FREQUENCY  40000000
-#define SPI_READ_FREQUENCY  20000000
 #define SPI_TOUCH_FREQUENCY  2500000
-
-#define TOUCH_DRIVER 0x2046


### PR DESCRIPTION
This PR updates the CYDSynth example with improved display and touch handling. Changes include:

- Updated User_Setup.h with simplified pin configurations
- Changed TOUCH_CS pin from 21 to 33
- Removed unnecessary display configuration parameters
- Improved code organization with better comments
- Simplified touch initialization using `setTouch(nullptr)`
- Removed unused touch pad driver include
- Removed redundant display initialization checks

These changes make the example more maintainable and improve the code structure while maintaining all functionality.